### PR TITLE
fix links in 简介.html

### DIFF
--- a/docs/简介.html
+++ b/docs/简介.html
@@ -178,8 +178,8 @@
 <li><p><strong>Linux Terminal</strong></p></li>
 <li><p><a class="reference external" href="https://cmder.net/">Cmder</a></p></li>
 <li><p><a class="reference external" href="https://www.netsarang.com/zh/xshell/">Xshell</a></p></li>
-<li><p><a class="reference external" href="https://www.putty.org/">Bitvise SSH</a></p></li>
-<li><p><a class="reference external" href="https://www.putty.org/">Putty</a> (表格字符会显示为q，但不影响使用)</p></li>
+<li><p><a class="reference external" href="https://bitvise.com/">Bitvise SSH</a></p></li>
+<li><p><a class="reference external" href="https://putty.software/">Putty</a> (表格字符会显示为q，但不影响使用)</p></li>
 <li><p><a class="reference external" href="https://eugeny.github.io/terminus/">Terminus</a> (某些情况下可能会出现奇怪的自动换行)</p></li>
 <li><p><strong>Windows Dos</strong> (需要自行设置为等宽字体，默认为点阵字体)</p></li>
 </ul>


### PR DESCRIPTION
Bitvise SSH was pointing to putty.org but should be bitvise.com Putty was pointing to putty.org, but that domain has no relation to the official PuTTY project, instead the correct domain run by the actual PuTTY team is https://putty.software/ , see https://hachyderm.io/@simontatham/115025974777386803